### PR TITLE
Update Security

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11158,11 +11158,6 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
       "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
     },
-    "react-lifecycles-compat": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
-    },
     "react-router": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.0.1.tgz",
@@ -11278,14 +11273,24 @@
       }
     },
     "react-transition-group": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.5.0.tgz",
-      "integrity": "sha512-qYB3JBF+9Y4sE4/Mg/9O6WFpdoYjeeYqx0AFb64PTazVy8RPMiE3A47CG9QmM4WJ/mzDiZYslV+Uly6O1Erlgw==",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.2.1.tgz",
+      "integrity": "sha512-IXrPr93VzCPupwm2O6n6C2kJIofJ/Rp5Ltihhm9UfE8lkuVX2ng/SUUl/oWjblybK9Fq2Io7LGa6maVqPB762Q==",
       "requires": {
-        "dom-helpers": "^3.3.1",
+        "@babel/runtime": "^7.4.5",
+        "dom-helpers": "^3.4.0",
         "loose-envify": "^1.4.0",
-        "prop-types": "^15.6.2",
-        "react-lifecycles-compat": "^3.0.4"
+        "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.4.tgz",
+          "integrity": "sha512-Na84uwyImZZc3FKf4aUF1tysApzwf3p2yuFBIyBfbzT5glzKTdvYI4KVW4kcgjrzoGUjC7w3YyCHcJKaRxsr2Q==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        }
       }
     },
     "read-pkg": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11000,14 +11000,25 @@
       "integrity": "sha512-btpYJuWOtPBiOW9osRu3O36kXbEK+J9HrJPwIbFZSd/r4wW3wJMBXLwASmilcE+mQIWupqmGdPyR+ZV+nKkSHA=="
     },
     "react": {
-      "version": "16.7.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.7.0.tgz",
-      "integrity": "sha512-StCz3QY8lxTb5cl2HJxjwLFOXPIFQp+p+hxQfc8WE0QiLfCtIlKj8/+5tjjKm8uSTlAW+fCPaavGFS06V9Ar3A==",
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.8.6.tgz",
+      "integrity": "sha512-pC0uMkhLaHm11ZSJULfOBqV4tIZkx87ZLvbbQYunNixAAvjnC+snJCg0XQXn9VIsttVsbZP/H/ewzgsd5fxKXw==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.12.0"
+        "scheduler": "^0.13.6"
+      },
+      "dependencies": {
+        "scheduler": {
+          "version": "0.13.6",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
+          "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "react-addons-clone-with-props": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6407,11 +6407,6 @@
         }
       }
     },
-    "gud": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
-    },
     "gzip-size": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.0.0.tgz",
@@ -8961,26 +8956,6 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
-    "mini-create-react-context": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.3.2.tgz",
-      "integrity": "sha512-2v+OeetEyliMt5VHMXsBhABoJ0/M4RCe7fatd/fBy6SMiKazUSEt3gxxypfnk2SHMkdBYvorHRoQxuGoiwbzAw==",
-      "requires": {
-        "@babel/runtime": "^7.4.0",
-        "gud": "^1.0.0",
-        "tiny-warning": "^1.0.2"
-      },
-      "dependencies": {
-        "@babel/runtime": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.4.tgz",
-          "integrity": "sha512-Na84uwyImZZc3FKf4aUF1tysApzwf3p2yuFBIyBfbzT5glzKTdvYI4KVW4kcgjrzoGUjC7w3YyCHcJKaRxsr2Q==",
-          "requires": {
-            "regenerator-runtime": "^0.13.2"
-          }
-        }
-      }
-    },
     "mini-css-extract-plugin": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.5.0.tgz",
@@ -11170,30 +11145,19 @@
       "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
     },
     "react-router": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.0.1.tgz",
-      "integrity": "sha512-EM7suCPNKb1NxcTZ2LEOWFtQBQRQXecLxVpdsP4DW4PbbqYWeRiLyV/Tt1SdCrvT2jcyXAXmVTmzvSzrPR63Bg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz",
+      "integrity": "sha512-yrvL8AogDh2X42Dt9iknk4wF4V8bWREPirFfS9gLU1huk6qK41sg7Z/1S81jjTrGHxa3B8R3J6xIkDAA6CVarg==",
       "requires": {
-        "@babel/runtime": "^7.1.2",
-        "history": "^4.9.0",
-        "hoist-non-react-statics": "^3.1.0",
+        "history": "^4.7.2",
+        "hoist-non-react-statics": "^2.5.0",
+        "invariant": "^2.2.4",
         "loose-envify": "^1.3.1",
-        "mini-create-react-context": "^0.3.0",
         "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.2",
-        "react-is": "^16.6.0",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "prop-types": "^15.6.1",
+        "warning": "^4.0.1"
       },
       "dependencies": {
-        "hoist-non-react-statics": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
-          "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
-          "requires": {
-            "react-is": "^16.7.0"
-          }
-        },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -11210,17 +11174,16 @@
       }
     },
     "react-router-dom": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.0.1.tgz",
-      "integrity": "sha512-zaVHSy7NN0G91/Bz9GD4owex5+eop+KvgbxXsP/O+iW1/Ln+BrJ8QiIR5a6xNPtrdTvLkxqlDClx13QO1uB8CA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.3.1.tgz",
+      "integrity": "sha512-c/MlywfxDdCp7EnB7YfPMOfMD3tOtIjrQlj/CKfNMBxdmpJP8xcz5P/UAFn3JbnQCNUxsHyVVqllF9LhgVyFCA==",
       "requires": {
-        "@babel/runtime": "^7.1.2",
-        "history": "^4.9.0",
+        "history": "^4.7.2",
+        "invariant": "^2.2.4",
         "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.2",
-        "react-router": "5.0.1",
-        "tiny-invariant": "^1.0.2",
-        "tiny-warning": "^1.0.0"
+        "prop-types": "^15.6.1",
+        "react-router": "^4.3.1",
+        "warning": "^4.0.1"
       }
     },
     "react-scripts": {
@@ -11816,15 +11779,6 @@
       "integrity": "sha512-FZeKhJglhJHk7eWG5YM0z46VHmI3KJpMBAQm3xa9meDvd+wevB5GuBB0wc0exPInZiBBHqi00DbS8AcvCGCFMw==",
       "requires": {
         "xmlchars": "^1.3.1"
-      }
-    },
-    "scheduler": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.12.0.tgz",
-      "integrity": "sha512-t7MBR28Akcp4Jm+QoR63XgAi9YgCUmgvDHqf5otgAj4QvdoBE4ImCX0ffehefePPG+aitiYHp0g/mW6s4Tp+dw==",
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
       }
     },
     "schema-utils": {
@@ -13311,6 +13265,14 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "requires": {
         "makeerror": "1.0.x"
+      }
+    },
+    "warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "requires": {
+        "loose-envify": "^1.0.0"
       }
     },
     "watchpack": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -919,13 +919,13 @@
       "integrity": "sha512-6It2EVfGskxZCQhuykrfnALg7oVeiI6KclWSmGDqB0AiInVrTGB9Jp9i4/Ad21u9Jde/voVQz6eFX/eSg/UsPA=="
     },
     "@firebase/app": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.4.4.tgz",
-      "integrity": "sha512-RcRFIafRHcXGNC5iXFeFX6NGHyx+LLidhpj5JPlcc+sgScjg80lFvYERKugHITQjklmHEzwzAhWxmfZEDAzmyQ==",
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.4.9.tgz",
+      "integrity": "sha512-M1An/Id2ozNWbEeanLmczqgu7nS7Qq62u8yjdGOuePhJNie61/10zwPNETGKW/M+sYD6JaZYIsIhP2bQF9ZoDQ==",
       "requires": {
         "@firebase/app-types": "0.4.0",
-        "@firebase/logger": "0.1.15",
-        "@firebase/util": "0.2.18",
+        "@firebase/logger": "0.1.17",
+        "@firebase/util": "0.2.20",
         "dom-storage": "2.1.0",
         "tslib": "1.9.3",
         "xmlhttprequest": "1.8.0"
@@ -950,15 +950,25 @@
       "integrity": "sha512-QEG9azYwssGWcb4NaKFHe3Piez0SG46nRlu76HM4/ob0sjjNpNTY1Z5C3IoeJYknp2kMzuQi0TTW8tjEgkUAUA=="
     },
     "@firebase/database": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.4.4.tgz",
-      "integrity": "sha512-za3q2adxozScSS9GbXbWnP0CiX4zQULxhh6Oa0p1+wDieD9N4p8SNpmhFwUkY239WO11Ffkhp6mQ6Hjibc/ZDg==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.4.6.tgz",
+      "integrity": "sha512-EpH5JUybuebVzUK1Z1wQ33Hjs8ZJbM6pyAlHDgWcqe4c7hNsHK8QNIxbQXHVfjCtu+EBneFM3MlYF5cWka5Kzw==",
       "requires": {
         "@firebase/database-types": "0.4.0",
-        "@firebase/logger": "0.1.15",
-        "@firebase/util": "0.2.18",
-        "faye-websocket": "0.11.1",
+        "@firebase/logger": "0.1.17",
+        "@firebase/util": "0.2.20",
+        "faye-websocket": "0.11.3",
         "tslib": "1.9.3"
+      },
+      "dependencies": {
+        "faye-websocket": {
+          "version": "0.11.3",
+          "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
+          "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
+          "requires": {
+            "websocket-driver": ">=0.5.1"
+          }
+        }
       }
     },
     "@firebase/database-types": {
@@ -967,46 +977,46 @@
       "integrity": "sha512-2piRYW7t+2s/P1NPpcI/3+8Y5l2WnJhm9KACoXW5zmoAPlya8R1aEaR2dNHLNePTMHdg04miEDD9fEz4xUqzZA=="
     },
     "@firebase/firestore": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-1.3.5.tgz",
-      "integrity": "sha512-iEwfCFwj5bC1ZuM3z//y45Gwz7pr8LGLR0dAHW0YJNP9oTHoKJrh+gda35i1qQuuOSt5DPNsdB4XPVLS9C+IUA==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-1.4.3.tgz",
+      "integrity": "sha512-P4AFVFRBcSKlfLbfXCbY9HUFF846v0ln26XTD9m8sASvPnsumDFkRTt/ClrEX/FCrVFSRLtEiOp36FmCAbTrGQ==",
       "requires": {
-        "@firebase/firestore-types": "1.3.0",
-        "@firebase/logger": "0.1.15",
-        "@firebase/webchannel-wrapper": "0.2.20",
+        "@firebase/firestore-types": "1.4.1",
+        "@firebase/logger": "0.1.17",
+        "@firebase/webchannel-wrapper": "0.2.21",
         "@grpc/proto-loader": "^0.5.0",
         "grpc": "1.20.3",
         "tslib": "1.9.3"
       }
     },
     "@firebase/firestore-types": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-1.3.0.tgz",
-      "integrity": "sha512-XPnfAaYsKgYivgl/U1+M5ulBG9Hxv52zrZR5TuaoKCU791t/E3K85rT1ZGtEHu9Fj4CPTep2NSl8I30MQpUlHA=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-1.4.1.tgz",
+      "integrity": "sha512-F+mpOAzA+Xk6rZ2KRtRpqp3fULLDaFGWPyTBZthHkgq8ku3Q/C/KGfWUNOy38M65Mb0WM5zQcOvNkYt/o+YQjA=="
     },
     "@firebase/functions": {
-      "version": "0.4.9",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.4.9.tgz",
-      "integrity": "sha512-0K6loEAiSYQC22Z0SK58lnTF32z1QmApj4yWDs+RwoZ0H6NgIAWEqYhh0ZVywngOusTeh2yDVUmDnTXrkYNZlQ==",
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.4.10.tgz",
+      "integrity": "sha512-agxHXkKCacJtThM2gctr6sKhUH3A3t9+YcM78SnEWdN8ubE4F8MaSsR0oPhpmFHcwJKEs+q5JieDmELTkRGjuw==",
       "requires": {
-        "@firebase/functions-types": "0.3.5",
+        "@firebase/functions-types": "0.3.6",
         "@firebase/messaging-types": "0.3.0",
         "isomorphic-fetch": "2.2.1",
         "tslib": "1.9.3"
       }
     },
     "@firebase/functions-types": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.3.5.tgz",
-      "integrity": "sha512-3hTMqfSugCfxzT6vZPbzQ58G4941rsFr99fWKXGKFAl2QpdMBCnKmEKdg/p5M47xIPyzIQn6NMF5kCo/eICXhA=="
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.3.6.tgz",
+      "integrity": "sha512-OIWXsaUBNSA7ifkrTFKwNMDgs1DCk6dC7xwofRBIrJP3ZxLPxRV79KyKKqcThe5Ie6JeG6oyFAIK5CMTYa5Ebg=="
     },
     "@firebase/installations": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.1.5.tgz",
-      "integrity": "sha512-dI4DCu8zRyhqTsVh1hwBgmg4uBZ8qGrDRuXiSS45MqnyX7qh8+v6UqY4VZpnErU3hj1FnMPDdgOKIaM2sujNCg==",
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.1.7.tgz",
+      "integrity": "sha512-+OxqxtiOS7fJaVNc886IurARFrcVK16DnWdrXn6XdIEE373OBo0Mh+PWyESU9uFh6Yx6h2z5a/b4IpVRT4QgGA==",
       "requires": {
         "@firebase/installations-types": "0.1.1",
-        "@firebase/util": "0.2.18",
+        "@firebase/util": "0.2.20",
         "idb": "3.0.2",
         "tslib": "1.9.3"
       }
@@ -1017,17 +1027,17 @@
       "integrity": "sha512-M+plQIOt6p+/j/ExUgsfXe1JFAKymhBU0K3+cp7hzj52vLSpklOqNJi4LkFl41pgRFPZeKf7MrTkMhVowg3Ukw=="
     },
     "@firebase/logger": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.1.15.tgz",
-      "integrity": "sha512-Xq8CdlPPZCAwZ1yspfyTO2YIoIlTV3QpjjCcBuOGR7q90457wdN5/2X8S2DjSiFfPtyPP/nTIT6Bs3Fi+upPTw=="
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.1.17.tgz",
+      "integrity": "sha512-vCuurlKhvEjN5SGbIGfHhVhMsRM6RknAjbEKbT6CgmD6fUnNH2oE1MwbafBK3nLc7i9sQFwZUU/fi4P0Nu/McQ=="
     },
     "@firebase/messaging": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.4.1.tgz",
-      "integrity": "sha512-USLPkKGmSNJao/Iq0mHad7YI87Cnf0ODag1d2pGFrcxMKIuFQs8xZ6BU05+5EmbSegeCWmlhZZAILxKqN0EEFA==",
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.4.3.tgz",
+      "integrity": "sha512-5X+ne6m9oK/CXvRecq+5WKzAoIO9/islwfr42QZEvtcGBGcBxezEA+4+kLbY1GekwVIblk/WMIquQLCdxwK9cg==",
       "requires": {
         "@firebase/messaging-types": "0.3.0",
-        "@firebase/util": "0.2.18",
+        "@firebase/util": "0.2.20",
         "tslib": "1.9.3"
       }
     },
@@ -1037,14 +1047,14 @@
       "integrity": "sha512-xCFMPy4C+WXFcshTnQEyddmqM6ZkzpTeJq7RUhrAvUnjlfFzOB92HOfKtjT6IpNk5W+jNbTTrqgrgReuPXsM2A=="
     },
     "@firebase/performance": {
-      "version": "0.2.6",
-      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.2.6.tgz",
-      "integrity": "sha512-6yHIIMPs8knok1LnqsBscRUbq5LbHK703OJg9R68MqqXiablLwcGeG6l2AiIjDsDN7tP4wRr691HGWX6IkqKFg==",
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.2.10.tgz",
+      "integrity": "sha512-LcUuY6rU+dA4jn8mq6zZN8JO50noup+peslS71ZZLQz1UdnpVhKAvUbS/M6TAzDlsn9uJaUyH8Fyt+vuwxdLcQ==",
       "requires": {
-        "@firebase/installations": "0.1.5",
-        "@firebase/logger": "0.1.15",
+        "@firebase/installations": "0.1.7",
+        "@firebase/logger": "0.1.17",
         "@firebase/performance-types": "0.0.2",
-        "@firebase/util": "0.2.18",
+        "@firebase/util": "0.2.20",
         "tslib": "1.9.3"
       }
     },
@@ -1071,31 +1081,31 @@
       }
     },
     "@firebase/storage": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.3.1.tgz",
-      "integrity": "sha512-kcsDmDGJ9QAcVC/1M53+zH3YpYH+zoeD2gZvxcFi1tiZq1dOT1yrz92xz40WZkwqVKf4MyxNnneqoAZad/OeKA==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.3.4.tgz",
+      "integrity": "sha512-2NHKgD7Ku5xMFeQqAWKV3WdX/ZC2yRPNBKcdHLvo/Y/DF2qkA1kmY4MWpuosr1pbxklSgqVA/3mueUWTsoakYw==",
       "requires": {
-        "@firebase/storage-types": "0.3.0",
+        "@firebase/storage-types": "0.3.1",
         "tslib": "1.9.3"
       }
     },
     "@firebase/storage-types": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.3.0.tgz",
-      "integrity": "sha512-zy24QU3xPXIOIAussB51fLID9F7j5NttKbs+3SqhKexU8kmNdwi1Lg91acSBuR1Oa/T8RRk5El9Jtd4dlTXjyQ=="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.3.1.tgz",
+      "integrity": "sha512-Vuf7/nSTWrvPmoZiwfQjI3ThqAKQXVLpozhoGVxoGM1qtITsnw+Oe/Fa+CW1/ZkelVBcy8ZWEB2aaHXaDu3h+Q=="
     },
     "@firebase/util": {
-      "version": "0.2.18",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.18.tgz",
-      "integrity": "sha512-I17vZZ/xRQu3hYvj/RikySSQFlfej+xXwh+yfdB6VhQavb4H5+NbX/5Tp3jSPp+7obFstVgqkM+yHjX/Z9+DXw==",
+      "version": "0.2.20",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.20.tgz",
+      "integrity": "sha512-Cu5T7RFV54eZdToPXcRKwn7rB0hImbkvLdAmno6mKkoV5s0xDgo9K0PBvftqp8Gg2aDR/B5p+ZjR6xDiSQ42sA==",
       "requires": {
         "tslib": "1.9.3"
       }
     },
     "@firebase/webchannel-wrapper": {
-      "version": "0.2.20",
-      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.2.20.tgz",
-      "integrity": "sha512-TpqR1qCn117fY4mrxSGqv/CT/iAM58sHdlS8ujj0Roa7DoleAHJzqOhNNoHCNncwvNDWcvygLsEiTBuDQZsv3A=="
+      "version": "0.2.21",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.2.21.tgz",
+      "integrity": "sha512-eL4xPPjTBceYKa27tN3SahSD/7k5ioKFGeZZZX67+aLuxxFts2eTCcotRAeKcjGu1xTz7GnWUkMsj4NZZTIGXg=="
     },
     "@grpc/proto-loader": {
       "version": "0.5.1",
@@ -5605,22 +5615,22 @@
       }
     },
     "firebase": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-6.1.1.tgz",
-      "integrity": "sha512-RB8ZGcj28tU1of6l/l7TBu0By/ewmsIZtrDSlxTp/C6uawN8QtDkGbW3mWV73nkjkFYP6PwMmzCoXtdKxHpRmQ==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-6.2.4.tgz",
+      "integrity": "sha512-vDWvqUKmWbTeg2z1Df+bbyPrRUWXXency0eH2CG62wpTmMJXJYKb+9mOlo3MlNOTsKkdrPqKxGHf9LF7ju58lw==",
       "requires": {
-        "@firebase/app": "0.4.4",
+        "@firebase/app": "0.4.9",
         "@firebase/app-types": "0.4.0",
         "@firebase/auth": "0.11.3",
-        "@firebase/database": "0.4.4",
-        "@firebase/firestore": "1.3.5",
-        "@firebase/functions": "0.4.9",
-        "@firebase/installations": "0.1.5",
-        "@firebase/messaging": "0.4.1",
-        "@firebase/performance": "0.2.6",
+        "@firebase/database": "0.4.6",
+        "@firebase/firestore": "1.4.3",
+        "@firebase/functions": "0.4.10",
+        "@firebase/installations": "0.1.7",
+        "@firebase/messaging": "0.4.3",
+        "@firebase/performance": "0.2.10",
         "@firebase/polyfill": "0.3.14",
-        "@firebase/storage": "0.3.1",
-        "@firebase/util": "0.2.18"
+        "@firebase/storage": "0.3.4",
+        "@firebase/util": "0.2.20"
       }
     },
     "flat-cache": {
@@ -10837,9 +10847,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.14.8",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.8.tgz",
-          "integrity": "sha512-I4+DbJEhLEg4/vIy/2gkWDvXBOOtPKV9EnLhYjMoqxcRW+TTZtUftkHktz/a8suoD5mUL7m6ReLrkPvSsCQQmw=="
+          "version": "10.14.12",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.12.tgz",
+          "integrity": "sha512-QcAKpaO6nhHLlxWBvpc4WeLrTvPqlHOvaj0s5GriKkA1zq+bsFBPpfYCvQhLqLgYlIko8A9YrPdaMHCo5mBcpg=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10783,12 +10783,13 @@
       }
     },
     "prop-types": {
-      "version": "15.6.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
-      "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+      "version": "15.7.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
       "requires": {
-        "loose-envify": "^1.3.1",
-        "object-assign": "^4.1.1"
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.8.1"
       }
     },
     "property-information": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8639,9 +8639,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6397,6 +6397,11 @@
         }
       }
     },
+    "gud": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
+      "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
+    },
     "gzip-size": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-5.0.0.tgz",
@@ -6572,25 +6577,16 @@
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
     },
     "history": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/history/-/history-4.7.2.tgz",
-      "integrity": "sha512-1zkBRWW6XweO0NBcjiphtVJVsIQ+SXF29z9DVkceeaSLVMFXHool+fdCZD4spDCfZJCILPILc3bm7Bc+HRi0nA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.9.0.tgz",
+      "integrity": "sha512-H2DkjCjXf0Op9OAr6nJ56fcRkTSNrUiv41vNJ6IswJjif6wlpZK0BTfFbi7qK9dXLSYZxkq5lBsj3vUjlYBYZA==",
       "requires": {
-        "invariant": "^2.2.1",
+        "@babel/runtime": "^7.1.2",
         "loose-envify": "^1.2.0",
         "resolve-pathname": "^2.2.0",
-        "value-equal": "^0.4.0",
-        "warning": "^3.0.0"
-      },
-      "dependencies": {
-        "warning": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
-          "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        }
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^0.4.0"
       }
     },
     "hmac-drbg": {
@@ -8955,6 +8951,26 @@
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
     },
+    "mini-create-react-context": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.3.2.tgz",
+      "integrity": "sha512-2v+OeetEyliMt5VHMXsBhABoJ0/M4RCe7fatd/fBy6SMiKazUSEt3gxxypfnk2SHMkdBYvorHRoQxuGoiwbzAw==",
+      "requires": {
+        "@babel/runtime": "^7.4.0",
+        "gud": "^1.0.0",
+        "tiny-warning": "^1.0.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.4.tgz",
+          "integrity": "sha512-Na84uwyImZZc3FKf4aUF1tysApzwf3p2yuFBIyBfbzT5glzKTdvYI4KVW4kcgjrzoGUjC7w3YyCHcJKaRxsr2Q==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        }
+      }
+    },
     "mini-css-extract-plugin": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.5.0.tgz",
@@ -11127,19 +11143,30 @@
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-router": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-4.3.1.tgz",
-      "integrity": "sha512-yrvL8AogDh2X42Dt9iknk4wF4V8bWREPirFfS9gLU1huk6qK41sg7Z/1S81jjTrGHxa3B8R3J6xIkDAA6CVarg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.0.1.tgz",
+      "integrity": "sha512-EM7suCPNKb1NxcTZ2LEOWFtQBQRQXecLxVpdsP4DW4PbbqYWeRiLyV/Tt1SdCrvT2jcyXAXmVTmzvSzrPR63Bg==",
       "requires": {
-        "history": "^4.7.2",
-        "hoist-non-react-statics": "^2.5.0",
-        "invariant": "^2.2.4",
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
         "loose-envify": "^1.3.1",
+        "mini-create-react-context": "^0.3.0",
         "path-to-regexp": "^1.7.0",
-        "prop-types": "^15.6.1",
-        "warning": "^4.0.1"
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
       },
       "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
+          "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+          "requires": {
+            "react-is": "^16.7.0"
+          }
+        },
         "isarray": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
@@ -11156,16 +11183,17 @@
       }
     },
     "react-router-dom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-4.3.1.tgz",
-      "integrity": "sha512-c/MlywfxDdCp7EnB7YfPMOfMD3tOtIjrQlj/CKfNMBxdmpJP8xcz5P/UAFn3JbnQCNUxsHyVVqllF9LhgVyFCA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.0.1.tgz",
+      "integrity": "sha512-zaVHSy7NN0G91/Bz9GD4owex5+eop+KvgbxXsP/O+iW1/Ln+BrJ8QiIR5a6xNPtrdTvLkxqlDClx13QO1uB8CA==",
       "requires": {
-        "history": "^4.7.2",
-        "invariant": "^2.2.4",
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
         "loose-envify": "^1.3.1",
-        "prop-types": "^15.6.1",
-        "react-router": "^4.3.1",
-        "warning": "^4.0.1"
+        "prop-types": "^15.6.2",
+        "react-router": "5.0.1",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
       }
     },
     "react-scripts": {
@@ -12680,6 +12708,16 @@
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
     },
+    "tiny-invariant": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.0.5.tgz",
+      "integrity": "sha512-BziszNEQNwtyMS9OVJia2LK9N9b6VJ35kBrvhDDDpr4hreLYqhCie15dB35uZMdqv9ZTQ55GHQtkz2FnleTHIA=="
+    },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -13236,14 +13274,6 @@
       "integrity": "sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=",
       "requires": {
         "makeerror": "1.0.x"
-      }
-    },
-    "warning": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.2.tgz",
-      "integrity": "sha512-wbTp09q/9C+jJn4KKJfJfoS6VleK/Dti0yqWSm6KMvJ4MRCXFQNapHuJXutJIrWV0Cf4AhTdeIe4qdKHR1+Hug==",
-      "requires": {
-        "loose-envify": "^1.0.0"
       }
     },
     "watchpack": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11127,14 +11127,25 @@
       }
     },
     "react-dom": {
-      "version": "16.7.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.7.0.tgz",
-      "integrity": "sha512-D0Ufv1ExCAmF38P2Uh1lwpminZFRXEINJe53zRAbm4KPwSyd6DY/uDoS0Blj9jvPpn1+wivKpZYc8aAAN/nAkg==",
+      "version": "16.8.6",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.6.tgz",
+      "integrity": "sha512-1nL7PIq9LTL3fthPqwkvr2zY7phIPjYrT0jp4HjyEQrEROnw4dG41VVwi/wfoCneoleqrNX7iAD+pXebJZwrwA==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.12.0"
+        "scheduler": "^0.13.6"
+      },
+      "dependencies": {
+        "scheduler": {
+          "version": "0.13.6",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.6.tgz",
+          "integrity": "sha512-IWnObHt413ucAYKsD9J1QShUKkbKLQQHdxRyw73sw4FN26iWr3DY/H34xGPe4nmL1DwXyWmSWmMrA9TfQbE/XQ==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        }
       }
     },
     "react-error-overlay": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "react-dom": "^16.8.6",
     "react-router-dom": "^4.3.1",
     "react-scripts": "^3.0.1",
-    "react-transition-group": "^2.5.0"
+    "react-transition-group": "^4.2.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "firebase": "^6.2.4",
     "prop-types": "^15.6.2",
     "re-base": "^4.0.0",
-    "react": "^16.7.0",
+    "react": "^16.8.6",
     "react-cookie-banner": "^4.0.0",
     "react-dom": "^16.8.6",
     "react-router-dom": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "re-base": "^4.0.0",
     "react": "^16.7.0",
     "react-cookie-banner": "^4.0.0",
-    "react-dom": "^16.7.0",
-    "react-router-dom": "^5.0.1",
+    "react-dom": "^16.8.6",
+    "react-router-dom": "^4.3.1",
     "react-scripts": "^3.0.1",
     "react-transition-group": "^2.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "homepage": "/",
   "dependencies": {
     "firebase": "^6.1.1",
-    "prop-types": "^15.6.2",
+    "prop-types": "^15.7.2",
     "re-base": "^4.0.0",
     "react": "^16.7.0",
     "react-cookie-banner": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "react": "^16.7.0",
     "react-cookie-banner": "^4.0.0",
     "react-dom": "^16.7.0",
-    "react-router-dom": "^4.3.1",
+    "react-router-dom": "^5.0.1",
     "react-scripts": "^3.0.1",
     "react-transition-group": "^2.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "homepage": "/",
   "dependencies": {
-    "firebase": "^6.1.1",
-    "prop-types": "^15.7.2",
+    "firebase": "^6.2.4",
+    "prop-types": "^15.6.2",
     "re-base": "^4.0.0",
     "react": "^16.7.0",
     "react-cookie-banner": "^4.0.0",


### PR DESCRIPTION
### Change :

- `Bump prop-types from 15.6.2 to 15.7.2`
- `Bump react-router-dom from 4.3.1 to 5.0.1`
- `Bump firebase from 6.1.1 to 6.2.4`
- `Bump react-dom from 16.7.0 to 16.8.6`
- `Bump react-transition-group from 2.5.0 to 4.2.1`
- `Bump react from 16.7.0 to 16.8.6`
- `[Security] Bump lodash from 4.17.11 to 4.17.14`
- `Bump lodash.template from 4.4.0 to 4.5.0`
- `Update security braces to 2.3.1 version`
- `Bump handlebars from 4.0.12 to 4.1.2`
- `Bump js-yaml from 3.12.1 to 3.13.1`