### PR TITLE
Update Security

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4349,6 +4349,11 @@
         "cssom": "0.3.x"
       }
     },
+    "csstype": {
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.6.tgz",
+      "integrity": "sha512-RpFbQGUE74iyPgvr46U9t1xoQBM8T4BL8SxrN66Le2xYAPSaDJJKeztV3awugusb3g3G9iL8StmkBBXhcbbXhg=="
+    },
     "cyclist": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-0.2.2.tgz",
@@ -4645,11 +4650,22 @@
       }
     },
     "dom-helpers": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
-      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.1.0.tgz",
+      "integrity": "sha512-zRRYDhpiKuAJHasOqCm7lBnsd22nrM4+OYI4ASWCxen+ocTMl7BIAKgGag97TlLiTl6rrau5aPe1VGUm9jQBng==",
       "requires": {
-        "@babel/runtime": "^7.1.2"
+        "@babel/runtime": "^7.5.5",
+        "csstype": "^2.6.6"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.0.tgz",
+          "integrity": "sha512-89eSBLJsxNxOERC0Op4vd+0Bqm6wRMqMbFtV3i0/fbaWw/mJ8Q3eBvgX0G4SyrOOLCtbu98HspF8o09MRT+KzQ==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        }
       }
     },
     "dom-serializer": {
@@ -11671,20 +11687,20 @@
       }
     },
     "react-transition-group": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.2.2.tgz",
-      "integrity": "sha512-uP0tjqewtvjb7kGZFpZYPoD/NlVZmIgts9eTt1w35pAaEApPxQGv94lD3VkqyXf2aMqrSGwhs6EV/DLaoKbLSw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.3.0.tgz",
+      "integrity": "sha512-1qRV1ZuVSdxPlPf4O8t7inxUGpdyO5zG9IoNfJxSO0ImU2A1YWkEQvFPuIPZmMLkg5hYs7vv5mMOyfgSkvAwvw==",
       "requires": {
-        "@babel/runtime": "^7.4.5",
-        "dom-helpers": "^3.4.0",
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.5.5",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.5.tgz",
-          "integrity": "sha512-28QvEGyQyNkB0/m2B4FU7IEZGK2NUrcMtT6BZEFALTguLk+AUT6ofsHtPk5QyjAdUkpMJ+/Em+quwz4HOt30AQ==",
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.0.tgz",
+          "integrity": "sha512-89eSBLJsxNxOERC0Op4vd+0Bqm6wRMqMbFtV3i0/fbaWw/mJ8Q3eBvgX0G4SyrOOLCtbu98HspF8o09MRT+KzQ==",
           "requires": {
             "regenerator-runtime": "^0.13.2"
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -6759,9 +6759,9 @@
       "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ=="
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.2.0.tgz",
+      "integrity": "sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==",
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -952,13 +952,13 @@
       "integrity": "sha512-6It2EVfGskxZCQhuykrfnALg7oVeiI6KclWSmGDqB0AiInVrTGB9Jp9i4/Ad21u9Jde/voVQz6eFX/eSg/UsPA=="
     },
     "@firebase/app": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.4.15.tgz",
-      "integrity": "sha512-/LEOJREQVNWiDulkVCSsnYT8e1Oiti84PawkEuIaO7KmiEairb3BOr+p3N3xFOCqv6rrZLnM7CEqa2voNBoIlQ==",
+      "version": "0.4.16",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.4.16.tgz",
+      "integrity": "sha512-4aa6ixQlV6xQxj4HbwFKrfYZnnKk8AtB/vEEuIaBCGQYBvV287OVNCozXd4CC4Q4I4Vtkzrc+kggahYFl8nDWQ==",
       "requires": {
         "@firebase/app-types": "0.4.3",
-        "@firebase/logger": "0.1.23",
-        "@firebase/util": "0.2.26",
+        "@firebase/logger": "0.1.24",
+        "@firebase/util": "0.2.27",
         "dom-storage": "2.1.0",
         "tslib": "1.10.0",
         "xmlhttprequest": "1.8.0"
@@ -977,26 +977,26 @@
       "integrity": "sha512-VU5c+ZjejvefLVH4cjiX3Hy1w9HYMv7TtZ1tF9ZmOqT4DSIU1a3VISWoo8///cGGffr5IirMO+Q/WZLI4p8VcA=="
     },
     "@firebase/auth": {
-      "version": "0.11.8",
-      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.11.8.tgz",
-      "integrity": "sha512-aMSWaOCQmQtLKb1j96O7tErRx+kgq2OV3tMV/sKLkXp1J7SP03ejQfi+wOGDYnTWD6mNv+7b8ra1po+IHkydtg==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.12.0.tgz",
+      "integrity": "sha512-DGYvAmz2aUmrWYS3ADw/UmsuicxJi6G+X38XITqNPUrd1YxmM5SBzX19oEb9WCrJZXcr4JaESg6hQkT2yEPaCA==",
       "requires": {
-        "@firebase/auth-types": "0.7.2"
+        "@firebase/auth-types": "0.8.0"
       }
     },
     "@firebase/auth-types": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.7.2.tgz",
-      "integrity": "sha512-xm3evp6671LoI+6M8Om3OhikabLf88Ivz1e7aR8uZjVBYptEYbF3seDIyHn/3wWdVYbp20WK4aWixKlRnHl+6Q=="
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.8.0.tgz",
+      "integrity": "sha512-foQHhvyB0RR+mb/+wmHXd/VOU+D8fruFEW1k79Q9wzyTPpovMBa1Mcns5fwEWBhUfi8bmoEtaGB8RSAHnTFzTg=="
     },
     "@firebase/database": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.5.1.tgz",
-      "integrity": "sha512-foXZVl32fUcekk+G8I0eWn2jJqWnJMKIsENKwtlBRbBai8ud8oqHkz704D35zff0MndsNlVxuWAEl4gaPLjRDQ==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.5.2.tgz",
+      "integrity": "sha512-LnXKRE1AmjlS+iRF7j8vx+Ni8x85CmLP5u5Pw5rDKhKLn2eTR1tJKD937mUeeGEtDHwR1rrrkLYOqRR2cSG3hQ==",
       "requires": {
         "@firebase/database-types": "0.4.3",
-        "@firebase/logger": "0.1.23",
-        "@firebase/util": "0.2.26",
+        "@firebase/logger": "0.1.24",
+        "@firebase/util": "0.2.27",
         "faye-websocket": "0.11.3",
         "tslib": "1.10.0"
       },
@@ -1017,16 +1017,16 @@
       }
     },
     "@firebase/firestore": {
-      "version": "1.4.12",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-1.4.12.tgz",
-      "integrity": "sha512-jkedv/QW7hGlVyiCr0h4m7pcuzUbQngDDH/5TY5xUDAF87sUId5VBbRFC8x+XQ94EdEeMYHbQkqn7uIYQVEJIA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-1.5.1.tgz",
+      "integrity": "sha512-W3XvAZQ1gwn6Sl1bJMUxzkF3qKIzyBKw8cQyGuYwo7ml6ME63tGvSScmEGjzFimvynrFhmSRJ16DPSVFe9LXmw==",
       "requires": {
-        "@firebase/firestore-types": "1.4.4",
-        "@firebase/logger": "0.1.23",
-        "@firebase/util": "0.2.26",
-        "@firebase/webchannel-wrapper": "0.2.25",
+        "@firebase/firestore-types": "1.5.0",
+        "@firebase/logger": "0.1.24",
+        "@firebase/util": "0.2.27",
+        "@firebase/webchannel-wrapper": "0.2.26",
         "@grpc/proto-loader": "^0.5.0",
-        "grpc": "1.22.2",
+        "grpc": "1.23.3",
         "tslib": "1.10.0"
       },
       "dependencies": {
@@ -1038,14 +1038,14 @@
       }
     },
     "@firebase/firestore-types": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-1.4.4.tgz",
-      "integrity": "sha512-kFpmzkUKfzrXkcMad+TQlMs55dWNY0q1UxGICW82EneX3Yg6HN3Nx36kYfqH+SLBFUN1ZTikN07alMp0MA9p9g=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-1.5.0.tgz",
+      "integrity": "sha512-VhRHNbEbak+R2iK8e1ir2Lec7eaHMZpGTRy6LMtzATYthlkwNHF9tO8JU8l6d1/kYkI4+DWzX++i3HhTziHEWA=="
     },
     "@firebase/functions": {
-      "version": "0.4.16",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.4.16.tgz",
-      "integrity": "sha512-ZRbg1375AXsB5+QdZV9i1oazBVl8AykWqIZEqa8KZFQVTD6hqXqiZcq6rhZH8EGttFnfGH6U1YoOyAHiXpD3dw==",
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.4.17.tgz",
+      "integrity": "sha512-heWMXrR3hgvQNe1JEZMUeY7a0QFLMVwVS+lzLq/lzk06bj22X9bJy7Yct+/P9P1ftnsCGLrhk3jAEuL78seoqg==",
       "requires": {
         "@firebase/functions-types": "0.3.8",
         "@firebase/messaging-types": "0.3.2",
@@ -1066,12 +1066,12 @@
       "integrity": "sha512-9hajHxA4UWVCGFmoL8PBYHpamE3JTNjObieMmnvZw3cMRTP2EwipMpzZi+GPbMlA/9swF9yHCY/XFAEkwbvdgQ=="
     },
     "@firebase/installations": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.2.5.tgz",
-      "integrity": "sha512-W52L9emgRVYjeYqQeSeqITDhnleskJizeKrcLJvLCJGBoZJ68wBtp0Hby1QiDQy7gyF/cG5Xy+x7bJYgrMmy0w==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.2.6.tgz",
+      "integrity": "sha512-hkuKmBtnsmqIfWxt9KyaN+cP574pfTcB81IG5tnmVcgP1xQ4hyQ9LRP0M7jDTGWMw272TInBzUuaM05xw9GMnA==",
       "requires": {
         "@firebase/installations-types": "0.1.2",
-        "@firebase/util": "0.2.26",
+        "@firebase/util": "0.2.27",
         "idb": "3.0.2",
         "tslib": "1.10.0"
       },
@@ -1089,17 +1089,17 @@
       "integrity": "sha512-fQaWIW8hyX1XUN7+FCSPjvM1agFjGidVuF4Sxi7aFwfyh5t+4fD2VpM4wCQbWmodnx4fZLvsuQd9mkxxU+lGYQ=="
     },
     "@firebase/logger": {
-      "version": "0.1.23",
-      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.1.23.tgz",
-      "integrity": "sha512-/j4B4w/10gy5pG1SCudnjpc5jjqTkIQ+MfSXf7nnED0uTHmdODIWy59YK3cAH3tV7L/OSYPLwcRen7XURXRijQ=="
+      "version": "0.1.24",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.1.24.tgz",
+      "integrity": "sha512-wPwhWCepEjWiTIqeC9U+7Hcw4XwezKPdXmyXbYSPiWNDcVekNgMPkntwSK+/2ufJO/1nMwAL2n6fL12oQG/PpQ=="
     },
     "@firebase/messaging": {
-      "version": "0.4.9",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.4.9.tgz",
-      "integrity": "sha512-9Lgc/foGtnrgou6bPm6/NWBG9EMGQM2Ub+h+RGA6mhjLuHLhSssfPaOysVMoPnEZwomz03YpeyQ2Bgz6FjkyyQ==",
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.4.10.tgz",
+      "integrity": "sha512-WqtSqlulV2ix4MZ3r1HwGAEj0DiEWtpNCSPh5wOXZsj8Kd01Q2QPTLUtUWmwXSV9WCQWnowfE2x8wjq5388ixw==",
       "requires": {
         "@firebase/messaging-types": "0.3.2",
-        "@firebase/util": "0.2.26",
+        "@firebase/util": "0.2.27",
         "tslib": "1.10.0"
       },
       "dependencies": {
@@ -1116,14 +1116,14 @@
       "integrity": "sha512-2qa2qNKqpalmtwaUV3+wQqfCm5myP/dViIBv+pXF8HinemIfO1IPQtr9pCNfsSYyus78qEhtfldnPWXxUH5v0w=="
     },
     "@firebase/performance": {
-      "version": "0.2.17",
-      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.2.17.tgz",
-      "integrity": "sha512-ybwTRxmpm4xiUCfApYFGZPGJIOWWxIc36Y0PxaaB0zWj4Ym1I1SDb0AGQ5mYOQj0VPlsGGsQtQ6E/gMl1NmaaA==",
+      "version": "0.2.18",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.2.18.tgz",
+      "integrity": "sha512-PcN+nTPaMGqODfwAXgwbaCvcxXH+YzvK6UpZzm0Bl9wmW28/oJipnUxF3cYbVGCiaLAaByIPVSIF22XhTOjUtA==",
       "requires": {
-        "@firebase/installations": "0.2.5",
-        "@firebase/logger": "0.1.23",
+        "@firebase/installations": "0.2.6",
+        "@firebase/logger": "0.1.24",
         "@firebase/performance-types": "0.0.3",
-        "@firebase/util": "0.2.26",
+        "@firebase/util": "0.2.27",
         "tslib": "1.10.0"
       },
       "dependencies": {
@@ -1140,9 +1140,9 @@
       "integrity": "sha512-RuC63nYJPJU65AsrNMc3fTRcRgHiyNcQLh9ufeKUT1mEsFgpxr167gMb+tpzNU4jsbvM6+c6nQAFdHpqcGkRlQ=="
     },
     "@firebase/polyfill": {
-      "version": "0.3.20",
-      "resolved": "https://registry.npmjs.org/@firebase/polyfill/-/polyfill-0.3.20.tgz",
-      "integrity": "sha512-FsuQjuHiG4LCm7yswl1ioAOsNfoCLMdAgyLZ0SMEppEUUKUdaIRe6YtZDM6RWveJeUy4NrlQx7xK2OEwf5onjg==",
+      "version": "0.3.21",
+      "resolved": "https://registry.npmjs.org/@firebase/polyfill/-/polyfill-0.3.21.tgz",
+      "integrity": "sha512-2mqS3FQHMhCGyfMGRsaZEypHSBD8hVmp9ZBnZSkn8hq5sSOLiNTFSC0FsvNu5z99GNsPQJFTui8bxcZl5cHQbw==",
       "requires": {
         "core-js": "3.2.1",
         "promise-polyfill": "8.1.3",
@@ -1162,12 +1162,12 @@
       }
     },
     "@firebase/storage": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.3.10.tgz",
-      "integrity": "sha512-cLi0kGcb0LZrvvNHZUmiXOBWVW+tK8HBnb5fBQ/neeVxEOnyVhgI3ONrnQLThELpDq3kxtXdvQqQK/WhpNIGHQ==",
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.3.11.tgz",
+      "integrity": "sha512-Q2ffXE+X62gFy5mZkg7qhzAC7+kqaNZWpgS+297h/hWr/cFBDyC8eBPmnI509eKi2okixmOMbWnNluZkNYNSfw==",
       "requires": {
         "@firebase/storage-types": "0.3.3",
-        "@firebase/util": "0.2.26",
+        "@firebase/util": "0.2.27",
         "tslib": "1.10.0"
       },
       "dependencies": {
@@ -1184,9 +1184,9 @@
       "integrity": "sha512-fUp4kpbxwDiWs/aIBJqBvXgFHZvgoND2JA0gJYSEsXtWtVwfgzY/710plErgZDeQKopX5eOR1sHskZkQUy0U6w=="
     },
     "@firebase/util": {
-      "version": "0.2.26",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.26.tgz",
-      "integrity": "sha512-GcKcDAlJ85i1MsURKr8v2k5fkE0FkuM0ap/rYuWs44vxd2U5x6fUdoUQrKnZlclTH/xj0z+qHVQB9Vrwvp7alw==",
+      "version": "0.2.27",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.27.tgz",
+      "integrity": "sha512-kFlbWNX1OuLfHrDXZ5QLmNNiLtMyxzbBgMo1DY1tXMjKK1AMYsHnyjInA8esvO0SCDp5XN3Pt9EDlhY4sRiLsw==",
       "requires": {
         "tslib": "1.10.0"
       },
@@ -1199,14 +1199,14 @@
       }
     },
     "@firebase/webchannel-wrapper": {
-      "version": "0.2.25",
-      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.2.25.tgz",
-      "integrity": "sha512-FHeGk7pymtfqZ6BI3TskaFfU/Vp8EsoTiPCFOwMEJb3L0mub3Z0PrTkC4IArELb6UDG1bfWSyxGxseLdIIhLIQ=="
+      "version": "0.2.26",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.2.26.tgz",
+      "integrity": "sha512-VlTurkvs4v7EVFWESBZGOPghFEokQhU5au5CP9WqA8B2/PcQRDsaaQlQCA6VATuEnW+vtSiSBvTiOc4004f8xg=="
     },
     "@grpc/proto-loader": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.1.tgz",
-      "integrity": "sha512-3y0FhacYAwWvyXshH18eDkUI40wT/uGio7MAegzY8lO5+wVsc19+1A7T0pPptae4kl7bdITL+0cHpnAPmryBjQ==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.5.2.tgz",
+      "integrity": "sha512-eBKD/FPxQoY1x6QONW2nBd54QUEyzcFP9FenujmoeDPy1rutVSHki1s/wR68F6O1QfCNDx+ayBH1O2CVNMzyyw==",
       "requires": {
         "lodash.camelcase": "^4.3.0",
         "protobufjs": "^6.8.6"
@@ -1683,6 +1683,15 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/bytebuffer": {
+      "version": "5.0.40",
+      "resolved": "https://registry.npmjs.org/@types/bytebuffer/-/bytebuffer-5.0.40.tgz",
+      "integrity": "sha512-h48dyzZrPMz25K6Q4+NCwWaxwXany2FhQg/ErOcdZS1ZpsaDnDMZg8JYLMTGz7uvXKrcKGJUZJlZObyfgdaN9g==",
+      "requires": {
+        "@types/long": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -1721,9 +1730,9 @@
       "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
     },
     "@types/node": {
-      "version": "10.14.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.16.tgz",
-      "integrity": "sha512-/opXIbfn0P+VLt+N8DE4l8Mn8rbhiJgabU96ZJ0p9mxOkIks5gh6RUnpHak7Yh0SFkyjO/ODbxsQQPV2bpMmyA=="
+      "version": "10.14.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.17.tgz",
+      "integrity": "sha512-p/sGgiPaathCfOtqu2fx5Mu1bcjuP8ALFg4xpGgNkcin7LwRyzUKniEHBKdcE1RPsenq5JVPIpMTJSygLboygQ=="
     },
     "@types/q": {
       "version": "1.5.2",
@@ -5884,22 +5893,22 @@
       }
     },
     "firebase": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-6.4.2.tgz",
-      "integrity": "sha512-2WxHVrd+4iIvAu30RGLYJbsZfXZMBEJON29dCMy+S22BstYvj1VnupYpV07/HUn6t38QcgoP8QGduKNgjSF3ng==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-6.6.0.tgz",
+      "integrity": "sha512-n6SiV0z7UF0cn2t/D+P0xQvnrwVXW41lRb1qw5GYgqc53FltIzPuFgv8yTx3q4Nt/vrFluyDqIbRnrAHGcPwjg==",
       "requires": {
-        "@firebase/app": "0.4.15",
+        "@firebase/app": "0.4.16",
         "@firebase/app-types": "0.4.3",
-        "@firebase/auth": "0.11.8",
-        "@firebase/database": "0.5.1",
-        "@firebase/firestore": "1.4.12",
-        "@firebase/functions": "0.4.16",
-        "@firebase/installations": "0.2.5",
-        "@firebase/messaging": "0.4.9",
-        "@firebase/performance": "0.2.17",
-        "@firebase/polyfill": "0.3.20",
-        "@firebase/storage": "0.3.10",
-        "@firebase/util": "0.2.26"
+        "@firebase/auth": "0.12.0",
+        "@firebase/database": "0.5.2",
+        "@firebase/firestore": "1.5.1",
+        "@firebase/functions": "0.4.17",
+        "@firebase/installations": "0.2.6",
+        "@firebase/messaging": "0.4.10",
+        "@firebase/performance": "0.2.18",
+        "@firebase/polyfill": "0.3.21",
+        "@firebase/storage": "0.3.11",
+        "@firebase/util": "0.2.27"
       }
     },
     "flat-cache": {
@@ -6264,10 +6273,11 @@
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE="
     },
     "grpc": {
-      "version": "1.22.2",
-      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.22.2.tgz",
-      "integrity": "sha512-gaK59oAA5/mlOIn+hQO5JROPoAzsaGRpEMcrAayW5WGETS8QScpBoQ+XBxEWAAF0kbeGIELuGRCVEObKS1SLmw==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.23.3.tgz",
+      "integrity": "sha512-7vdzxPw9s5UYch4aUn4hyM5tMaouaxUUkwkgJlwbR4AXMxiYZJOv19N2ps2eKiuUbJovo5fnGF9hg/X91gWYjw==",
       "requires": {
+        "@types/bytebuffer": "^5.0.40",
         "lodash.camelcase": "^4.3.0",
         "lodash.clone": "^4.5.0",
         "nan": "^2.13.2",
@@ -6313,7 +6323,7 @@
           "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
         },
         "chownr": {
-          "version": "1.1.1",
+          "version": "1.1.2",
           "bundled": true
         },
         "cliui": {
@@ -6341,6 +6351,13 @@
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true
+        },
+        "debug": {
+          "version": "3.2.6",
+          "bundled": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
         },
         "deep-extend": {
           "version": "0.6.0",
@@ -6379,12 +6396,24 @@
             "wide-align": "^1.1.0"
           }
         },
+        "glob": {
+          "version": "7.1.4",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true
         },
         "iconv-lite": {
-          "version": "0.4.23",
+          "version": "0.4.24",
           "bundled": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
@@ -6406,7 +6435,7 @@
           }
         },
         "inherits": {
-          "version": "2.0.3",
+          "version": "2.0.4",
           "bundled": true
         },
         "ini": {
@@ -6463,6 +6492,10 @@
             }
           }
         },
+        "ms": {
+          "version": "2.1.2",
+          "bundled": true
+        },
         "needle": {
           "version": "2.4.0",
           "bundled": true,
@@ -6470,19 +6503,6 @@
             "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.2.6",
-              "bundled": true,
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            },
-            "ms": {
-              "version": "2.1.2",
-              "bundled": true
-            }
           }
         },
         "node-pre-gyp": {
@@ -6514,7 +6534,7 @@
           "bundled": true
         },
         "npm-packlist": {
-          "version": "1.4.1",
+          "version": "1.4.4",
           "bundled": true,
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -6613,24 +6633,10 @@
           }
         },
         "rimraf": {
-          "version": "2.6.3",
+          "version": "2.7.1",
           "bundled": true,
           "requires": {
             "glob": "^7.1.3"
-          },
-          "dependencies": {
-            "glob": {
-              "version": "7.1.4",
-              "bundled": true,
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            }
           }
         },
         "safe-buffer": {
@@ -6646,7 +6652,7 @@
           "bundled": true
         },
         "semver": {
-          "version": "5.7.0",
+          "version": "5.7.1",
           "bundled": true
         },
         "set-blocking": {
@@ -6654,7 +6660,7 @@
           "bundled": true
         },
         "signal-exit": {
-          "version": "3.0.1",
+          "version": "3.0.2",
           "bundled": true
         },
         "string-width": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4974,9 +4974,9 @@
       }
     },
     "eslint": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.2.2.tgz",
-      "integrity": "sha512-mf0elOkxHbdyGX1IJEUsNBzCDdyoUgljF3rRlgfyYh0pwGnreLc0jjD6ZuleOibjmnUWZLY2eXwSooeOgGJ2jw==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-6.3.0.tgz",
+      "integrity": "sha512-ZvZTKaqDue+N8Y9g0kp6UPZtS4FSY3qARxBs7p4f0H0iof381XHduqVerFWtK8DPtKmemqbqCFENWSQgPR/Gow==",
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.10.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "homepage": "/",
   "dependencies": {
-    "firebase": "^6.4.2",
+    "firebase": "^6.6.0",
     "prop-types": "^15.6.2",
     "re-base": "^4.0.0",
     "react": "^16.9.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "braces": "^3.0.2",
     "eslint": "^6.2.2",
-    "handlebars": "^4.1.2",
+    "handlebars": "^4.2.0",
     "lodash": "^4.17.15",
     "querystringify": "^2.1.1"
   }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "react-dom": "^16.9.0",
     "react-router-dom": "^5.0.1",
     "react-scripts": "^3.1.1",
-    "react-transition-group": "^4.2.2"
+    "react-transition-group": "^4.3.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "devDependencies": {
     "braces": "^3.0.2",
-    "eslint": "^6.2.2",
+    "eslint": "^6.3.0",
     "handlebars": "^4.2.0",
     "lodash": "^4.17.15",
     "querystringify": "^2.1.1"


### PR DESCRIPTION
### Change : 

- `Bump eslint from 6.2.2 to 6.3.0`
- `Bump firebase from 6.4.2 to 6.6.0`
- `Bump handlebars from 4.1.2 to 4.2.0`
- `Bump react-transition-group from 4.2.2 to 4.3.0`